### PR TITLE
README.md: Correct the 'git config' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Using this
 To use this repository you need to have Git and Git Annex installed. Then:
 
     git clone git://github.com/ocharles/papers
-    git config remote.origin.annex-sync false
+    git config remote.origin.annex-readonly true
     git annex init local-copy
     git annex get .
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Using this
 To use this repository you need to have Git and Git Annex installed. Then:
 
     git clone git://github.com/ocharles/papers
-    git config remote.upstream.annex-sync=false
+    git config remote.origin.annex-sync false
     git annex init local-copy
     git annex get .
 


### PR DESCRIPTION
Hello,

Thanks for maintaining this collection!  (I came across it when looking through the repos as https://git-annex.branchable.com/publicrepos/)

This PR fixes #10.

---

Git expects a space, not '=', between the key and value, and clone
will name the remote "origin" by default.

Fixes #10.